### PR TITLE
refactor:💄 reduce unsafe codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zenhan-rs"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "windows",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenhan-rs"
-version = "0.1.1"
+version = "0.2.1"
 edition = "2021"
 authors = ["demerara151 <pinpinroku@tutanota.com>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenhan-rs"
-version = "0.2.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["demerara151 <pinpinroku@tutanota.com>"]
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,9 @@ fn main() -> Result<()> {
 fn get_input_mode() -> LPARAM {
     let args: Vec<String> = std::env::args().collect();
 
-    // HACK: Consider using more proper way in Rust.
-    if args.len() < 2 {
-        LPARAM(0)
-    } else {
-        let mode = args[1].parse().unwrap_or_default();
-        LPARAM(mode)
+    match args.get(1).map(|arg| arg.parse().unwrap_or_default()) {
+        Some(mode) => LPARAM(mode),
+        None => LPARAM(0),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,31 @@
 use windows::core::Result;
 use windows::Win32::Foundation::{LPARAM, WPARAM};
-use windows::Win32::UI::Input::Ime::{
-    ImmGetDefaultIMEWnd, IMC_SETOPENSTATUS, IMN_OPENSTATUSWINDOW,
-};
+use windows::Win32::UI::Input::Ime::{ImmGetDefaultIMEWnd, IMC_SETOPENSTATUS};
 use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, SendMessageA, WM_IME_CONTROL};
 
 fn main() -> Result<()> {
+    let set_open_status = WPARAM(IMC_SETOPENSTATUS.try_into()?);
+
+    let mode = get_input_mode();
+
     unsafe {
         let hwnd = GetForegroundWindow();
         let ime = ImmGetDefaultIMEWnd(hwnd);
 
-        let args: Vec<String> = std::env::args().collect();
-        if args.len() < 2 {
-            SendMessageA(
-                ime,
-                WM_IME_CONTROL,
-                WPARAM(IMN_OPENSTATUSWINDOW.try_into()?),
-                LPARAM(0),
-            );
-        } else {
-            let mode = args[1].parse().unwrap_or_default();
-            SendMessageA(
-                ime,
-                WM_IME_CONTROL,
-                WPARAM(IMC_SETOPENSTATUS.try_into()?),
-                LPARAM(mode),
-            );
-        }
+        SendMessageA(ime, WM_IME_CONTROL, set_open_status, mode);
     }
     Ok(())
+}
+
+fn get_input_mode() -> LPARAM {
+    let args: Vec<String> = std::env::args().collect();
+
+    // HACK: Consider using more proper way in Rust.
+    if args.len() < 2 {
+        LPARAM(0)
+    } else {
+        let mode = args[1].parse().unwrap_or_default();
+        LPARAM(mode)
+    }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ use windows::Win32::UI::Input::Ime::{ImmGetDefaultIMEWnd, IMC_SETOPENSTATUS};
 use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, SendMessageA, WM_IME_CONTROL};
 
 fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let mode = get_input_mode(args);
     let set_open_status = WPARAM(IMC_SETOPENSTATUS.try_into()?);
-
-    let mode = get_input_mode();
 
     unsafe {
         let hwnd = GetForegroundWindow();
@@ -17,12 +17,39 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn get_input_mode() -> LPARAM {
-    let args: Vec<String> = std::env::args().collect();
-
+fn get_input_mode(args: Vec<String>) -> LPARAM {
     match args.get(1).map(|arg| arg.parse().unwrap_or_default()) {
         Some(mode) => LPARAM(mode),
         None => LPARAM(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_input_mode_with_argument() {
+        let args = vec!["path/to/executable".to_string(), "1".to_string()];
+
+        let mode = get_input_mode(args);
+        assert_eq!(mode.0, 1);
+    }
+
+    #[test]
+    fn test_get_input_mode_with_invalid_argument() {
+        let args = vec!["path/to/executable".to_string(), "日本語".to_string()];
+
+        let mode = get_input_mode(args);
+        assert_eq!(mode.0, 0);
+    }
+
+    #[test]
+    fn test_get_input_mode_without_argument() {
+        let args = vec!["path/to/executable".to_string()];
+
+        let mode = get_input_mode(args);
+        assert_eq!(mode.0, 0);
     }
 }
 


### PR DESCRIPTION
## Refactor

Extract function that determine input mode from commandline arguments.

- Change conditional statements to more rustic way.
- Add tests for that function.
- Update minor version of this program to v0.2.0.