### PR TITLE
optimization:⚙️ (api): use unicode version for the function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "zenhan-rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "windows",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenhan-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["demerara151 <pinpinroku@tutanota.com>"]
 license = "MIT"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use windows::core::Result;
 use windows::Win32::Foundation::{LPARAM, WPARAM};
 use windows::Win32::UI::Input::Ime::{ImmGetDefaultIMEWnd, IMC_SETOPENSTATUS};
-use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, SendMessageA, WM_IME_CONTROL};
+use windows::Win32::UI::WindowsAndMessaging::{GetForegroundWindow, SendMessageW, WM_IME_CONTROL};
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
@@ -12,7 +12,7 @@ fn main() -> Result<()> {
         let hwnd = GetForegroundWindow();
         let ime = ImmGetDefaultIMEWnd(hwnd);
 
-        SendMessageA(ime, WM_IME_CONTROL, set_open_status, mode);
+        SendMessageW(ime, WM_IME_CONTROL, set_open_status, mode);
     }
     Ok(())
 }


### PR DESCRIPTION
## Changes

Small but important changes.

Windows API provide two versions of functions.
I was using function `SendMessageA()`.
Suffix `A` is for ASCII, and suffix `W` is for Unicode. Unicode is recommended for modern use case.
So I switch to that function to unicode version `SendMessageW()`.

## References

- [Unicode and Character Sets](https://learn.microsoft.com/en-us/windows/win32/intl/unicode-and-character-sets)
- [Unicode in the Windows API](https://learn.microsoft.com/en-us/windows/win32/intl/unicode-in-the-windows-api)